### PR TITLE
Autogenerate compilation database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 test/build
+**/compile_commands.json

--- a/definitions.mk
+++ b/definitions.mk
@@ -1,3 +1,4 @@
+
 define current-dir
 $(strip $(patsubst %/, %, $(dir $(lastword $(MAKEFILE_LIST)))))
 endef
@@ -7,13 +8,23 @@ $(wildcard $(1)/*/build.mk)
 endef
 
 define get-build-header
-"[$(GREEN_BOLD_COLOR)$(strip $(1))$(RESET_COLOR)] $(strip $(2))" 
+"[$(GREEN_BOLD_COLOR)$(strip $(1))$(RESET_COLOR)] $(strip $(2))"
 endef
 
 define print-build-header
 $(ECHO) $(call get-build-header, $(1), $(2))
 endef
 
-define get-include-exports-for-libs
-$(foreach LIB_TARGET_NAME, $(1), $(addprefix -I, $(TARGET_$(LIB_TARGET_NAME)_EXPORT_DIRS)))
+# Updates the LIB_INCLUDE_DIRS variable with the exported directories of linked libraries
+# $(1): List of linked libraries for current target
+define generate-include-exports-for-target
+$(eval LIB_INCLUDE_DIRS := $(foreach LIB_TARGET_NAME, $(1), $(addprefix -I, $(TARGET_$(LIB_TARGET_NAME)_EXPORT_DIRS))))
+endef
+
+# Generates the target partial compilation database (-MJ option) when using clang.
+# Updates the COMP_DB variable.
+# $(1): selected compiler
+# $(2): current target
+define generate-target-db
+$(eval COMP_DB := $(if $(findstring clang, $(1)), -MJ $(patsubst %.o, %.db, $(2)), ))
 endef

--- a/test/nested_shared/build.mk
+++ b/test/nested_shared/build.mk
@@ -1,7 +1,7 @@
 LOCAL_DIR := $(call current-dir)
 
-CC := gcc
-CXX := g++
+CC := clang
+CXX := clang++
 
 include $(CLEAR_VARS)
 LOCAL_NAME := test_nested_shared

--- a/top.mk
+++ b/top.mk
@@ -1,8 +1,10 @@
 BUILD_SYSTEM_DIR        ?= .
 BUILD_DIR               ?= build
+SYMLINK_COMP_DB         ?= . # Clear this variable if you don't want to generate the symlink
 BUILD_TARGET_DIR        := $(BUILD_DIR)/targets
 BUILD_INTERMEDIATES_DIR := $(BUILD_DIR)/intermediates
 BUILD_LIBS_DIR          := $(BUILD_DIR)/lib
+BUILD_COMP_DB_FILE      := $(BUILD_DIR)/compile_commands.json
 
 BUILD_BINARY            := $(BUILD_SYSTEM_DIR)/build_binary.mk
 BUILD_SHARED_LIB        := $(BUILD_SYSTEM_DIR)/build_shared_lib.mk
@@ -20,8 +22,23 @@ ECHO                    := $(SILENT)echo
 RM                      := $(SILENT)rm
 CP                      := $(SILENT)cp
 
-#default rule
-all:
+ALL_DB_FILES            :=
+
+#default rule, don't move
+all: compdb all_targets
+.PHONY: all
+
+all_targets:
+.PHONY: all_targets
+
+compdb: $(BUILD_COMP_DB_FILE)
+.PHONY: compdb
+
+# Merge partial compilation database files
+$(BUILD_COMP_DB_FILE):
+	$(call print-build-header, COMP_DB,)
+	$(if $(ALL_DB_FILES), $(shell sed -e '1s/^/[\n/' -e '$$s/,$$/\n]/' $(ALL_DB_FILES) > $@))
+	$(if $(SYMLINK_COMP_DB), $(shell ln -s -f $@ $(addsuffix /compile_commands.json, $(SYMLINK_COMP_DB))))
 
 clean:
 	$(ECHO) "Removing build directory"


### PR DESCRIPTION
Generate a compilation database when using clang.
By default create a symlink to the top folder (where the Makefile is)

Closes #7