### PR TITLE
Improve compilation database generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Its design was inspired by the AOSP build system, although it is much lighter an
 
 ### Dependencies
 
-In addition to `GNU make`, you will need also `Python 3` and `bear`.
+In addition to `GNU make`, you will need also `Python 3`.
 
 ```bash
-sudo apt install make python3 bear
+sudo apt install make python3
 ```
 
 ### Using the build system

--- a/build_binary_common.mk
+++ b/build_binary_common.mk
@@ -30,9 +30,13 @@ LOCAL_AR                := $(LOCAL_CROSS_COMPILE)$(AR)
 # Apply compiler profile
 -include $(CONFIG_DIR)/$(LOCAL_COMPILER).mk
 
-LOCAL_DB_FILES := $(patsubst %.o, %.db, $(LOCAL_C_OBJ)) \
-                  $(patsubst %.o, %.db, $(LOCAL_CXX_OBJ)) \
-                  $(patsubst %.o, %.db, $(LOCAL_CC_OBJ))
+LOCAL_C_DB_FILES := $(patsubst %.o, %.db, $(LOCAL_C_OBJ))
+LOCAL_CXX_DB_FILES := $(patsubst %.o, %.db, $(LOCAL_CXX_OBJ))
+LOCAL_CC_DB_FILES := $(patsubst %.o, %.db, $(LOCAL_CC_OBJ))
+LOCAL_DB_FILES := \
+    $(LOCAL_C_DB_FILES) \
+    $(LOCAL_CXX_DB_FILES) \
+    $(LOCAL_CC_DB_FILES)
 ALL_DB_FILES += $(LOCAL_DB_FILES)
 $(BUILD_COMP_DB_FILE): $(LOCAL_DB_FILES)
 
@@ -62,7 +66,17 @@ $(LOCAL_C_OBJ): $(LOCAL_INTERMEDIATES)/%.o: %.c $(LOCAL_SHARED_LIB_PATHS) $(LOCA
 	$(call print-build-header, $(INTERNAL_TARGET_NAME), CC $(notdir $<))
 	$(MKDIR) $(dir $@)
 	$(call generate-include-exports-for-target, $(INTERNAL_LIBS))
-	$(call trace-c-build, $@, $(INTERNAL_CC) -c $(INTERNAL_CFLAGS) $(LIB_INCLUDE_DIRS) -o $@ $< -MMD)
+	$(SILENT)$(INTERNAL_CC) -c $(INTERNAL_CFLAGS) $(LIB_INCLUDE_DIRS) -o $@ $< -MMD
+
+$(LOCAL_C_DB_FILES): INTERNAL_TARGET_NAME := $(LOCAL_NAME)
+$(LOCAL_C_DB_FILES): INTERNAL_CC := $(LOCAL_CC)
+$(LOCAL_C_DB_FILES): INTERNAL_CFLAGS := $(LOCAL_CFLAGS)
+$(LOCAL_C_DB_FILES): INTERNAL_LIBS := $(LOCAL_LIBS)
+$(LOCAL_C_DB_FILES): $(LOCAL_INTERMEDIATES)/%.db: %.c $(MK_DEPS)
+	$(call print-build-header, $(INTERNAL_TARGET_NAME), DB $(notdir $<))
+	$(MKDIR) $(dir $@)
+	$(call generate-include-exports-for-target, $(INTERNAL_LIBS))
+	$(GEN_COMPDB) --command "$(INTERNAL_CC) -c $(INTERNAL_CFLAGS) $(LIB_INCLUDE_DIRS) -o $(patsubst %.db, %.o, $@) $< -MMD" --file $< --output $@
 
 $(LOCAL_CXX_OBJ): INTERNAL_TARGET_NAME := $(LOCAL_NAME)
 $(LOCAL_CXX_OBJ): INTERNAL_CXX := $(LOCAL_CXX)
@@ -72,7 +86,17 @@ $(LOCAL_CXX_OBJ): $(LOCAL_INTERMEDIATES)/%.o: %.cpp $(LOCAL_SHARED_LIB_PATHS) $(
 	$(call print-build-header, $(INTERNAL_TARGET_NAME), CXX $(notdir $<))
 	$(MKDIR) $(dir $@)
 	$(call generate-include-exports-for-target, $(INTERNAL_LIBS))
-	$(call trace-c++-build, $@, $(INTERNAL_CXX) -c $(INTERNAL_CXXFLAGS) $(LIB_INCLUDE_DIRS) -o $@ $< -MMD)
+	$(SILENT)$(INTERNAL_CXX) -c $(INTERNAL_CXXFLAGS) $(LIB_INCLUDE_DIRS) -o $@ $< -MMD
+
+$(LOCAL_CXX_DB_FILES): INTERNAL_TARGET_NAME := $(LOCAL_NAME)
+$(LOCAL_CXX_DB_FILES): INTERNAL_CXX := $(LOCAL_CXX)
+$(LOCAL_CXX_DB_FILES): INTERNAL_CXXFLAGS := $(LOCAL_CXXFLAGS)
+$(LOCAL_CXX_DB_FILES): INTERNAL_LIBS := $(LOCAL_LIBS)
+$(LOCAL_CXX_DB_FILES): $(LOCAL_INTERMEDIATES)/%.db: %.cpp $(MK_DEPS)
+	$(call print-build-header, $(INTERNAL_TARGET_NAME), DB $(notdir $<))
+	$(MKDIR) $(dir $@)
+	$(call generate-include-exports-for-target, $(INTERNAL_LIBS))
+	$(GEN_COMPDB) --command "$(INTERNAL_CXX) -c $(INTERNAL_CXXFLAGS) $(LIB_INCLUDE_DIRS) -o $(patsubst %.db, %.o, $@) $< -MMD" --file $< --output $@
 
 $(LOCAL_CC_OBJ): INTERNAL_TARGET_NAME := $(LOCAL_NAME)
 $(LOCAL_CC_OBJ): INTERNAL_CXX := $(LOCAL_CXX)
@@ -82,7 +106,17 @@ $(LOCAL_CC_OBJ): $(LOCAL_INTERMEDIATES)/%.o: %.cc $(LOCAL_SHARED_LIB_PATHS) $(LO
 	$(call print-build-header, $(INTERNAL_TARGET_NAME), CXX $(notdir $<))
 	$(MKDIR) $(dir $@)
 	$(call generate-include-exports-for-target, $(INTERNAL_LIBS))
-	$(call trace-c++-build, $@, $(INTERNAL_CXX) -c $(INTERNAL_CXXFLAGS) $(LIB_INCLUDE_DIRS) -o $@ $< -MMD)
+	$(SILENT)$(INTERNAL_CXX) -c $(INTERNAL_CXXFLAGS) $(LIB_INCLUDE_DIRS) -o $@ $< -MMD
+
+$(LOCAL_CC_DB_FILES): INTERNAL_TARGET_NAME := $(LOCAL_NAME)
+$(LOCAL_CC_DB_FILES): INTERNAL_CXX := $(LOCAL_CXX)
+$(LOCAL_CC_DB_FILES): INTERNAL_CXXFLAGS := $(LOCAL_CXXFLAGS)
+$(LOCAL_CC_DB_FILES): INTERNAL_LIBS := $(LOCAL_LIBS)
+$(LOCAL_CC_DB_FILES): $(LOCAL_INTERMEDIATES)/%.db: %.cc $(MK_DEPS)
+	$(call print-build-header, $(INTERNAL_TARGET_NAME), DB $(notdir $<))
+	$(MKDIR) $(dir $@)
+	$(call generate-include-exports-for-target, $(INTERNAL_LIBS))
+	$(GEN_COMPDB) --command "$(INTERNAL_CXX) -c $(INTERNAL_CXXFLAGS) $(LIB_INCLUDE_DIRS) -o $(patsubst %.db, %.o, $@) $< -MMD" --file $< --output $@
 
 $(LOCAL_S_OBJ): INTERNAL_TARGET_NAME := $(LOCAL_NAME)
 $(LOCAL_S_OBJ): INTERNAL_AS := $(LOCAL_AS)

--- a/gen_compdb.py
+++ b/gen_compdb.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+""" Creates a compilation database entry for the given command """
+
+import json
+import argparse
+import os
+
+def generate_db_json(source_file, command):
+    """ Generates a single compilation database string from
+        all provided files """
+    compdb = [
+        {
+            "arguments": command.split(),
+            "directory": os.getcwd(),
+            "file": source_file
+        }
+    ]
+    return json.dumps(compdb, indent=4)
+
+def main():
+    """ Entrypoint for the program """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--file",
+                        help='File to build',
+                        required=True)
+    parser.add_argument("--command",
+                        help='command to build',
+                        required=True)
+    parser.add_argument('--output', nargs='?',
+                        help='Output file. Defaults to file.json',
+                        default='file.json')
+    args = parser.parse_args()
+
+    comp_db = generate_db_json(args.file, args.command)
+    with open(args.output, 'w') as output_file:
+        output_file.write(comp_db)
+
+if __name__ == '__main__':
+    main()

--- a/top.mk
+++ b/top.mk
@@ -1,6 +1,5 @@
 BUILD_SYSTEM_DIR        ?= .
 BUILD_DIR               ?= build
-SYMLINK_COMP_DB         ?= . # Clear this variable if you don't want to generate the symlink
 CONFIG_DIR              := $(BUILD_SYSTEM_DIR)/config
 
 BUILD_TARGET_DIR        := $(BUILD_DIR)/targets
@@ -9,7 +8,7 @@ BUILD_INTERMEDIATES_DIR := $(BUILD_DIR)/intermediates
 BUILD_GENERATED_SRC_DIR := $(BUILD_DIR)/gensrcs
 BUILD_LIBS_DIR          := $(BUILD_DIR)/lib
 BUILD_LINKER_SCRIPT_DIR := $(BUILD_DIR)/linker_script
-BUILD_COMP_DB_FILE      := $(BUILD_DIR)/compile_commands.json
+BUILD_COMP_DB_FILE      := compile_commands.json
 
 BUILD_BINARY            := $(BUILD_SYSTEM_DIR)/build_binary.mk
 BUILD_SHARED_LIB        := $(BUILD_SYSTEM_DIR)/build_shared_lib.mk
@@ -27,8 +26,8 @@ MKDIR                   := $(SILENT)mkdir -p
 ECHO                    := $(SILENT)echo
 RM                      := $(SILENT)rm
 CP                      := $(SILENT)cp
-BEAR                    := $(SILENT)bear
 MERGE_COMPDB            := $(SILENT)$(BUILD_SYSTEM_DIR)/merge_compdb.py
+GEN_COMPDB              := $(SILENT)$(BUILD_SYSTEM_DIR)/gen_compdb.py
 
 ALL_DB_FILES            :=
 
@@ -54,12 +53,9 @@ compdb: $(BUILD_COMP_DB_FILE)
 $(BUILD_COMP_DB_FILE):
 	$(call print-build-header, COMP_DB,)
 	$(MERGE_COMPDB) --output $@ --files $^
-	$(if $(SYMLINK_COMP_DB), $(shell ln -s -f $@ $(addsuffix /compile_commands.json, $(SYMLINK_COMP_DB))))
 
 clean:
 	$(ECHO) "Removing build directory"
 	$(RM) -rf $(BUILD_DIR)
-
-%.db: %.o ;
 
 include $(BUILD_SYSTEM_DIR)/gtest/build.mk


### PR DESCRIPTION
The compilation database does not need to build the sources. Knowing
what commands will be used to build the sources simplifies the
generation to just creating a json file with the command.

Drops the requirement for bear now that we have our own generation
script.

Change-Id: I7bcb1f4b3c4af12c4c9c979a4a5eea64b7918e2c