### PR TITLE
Fix clang-12 build

### DIFF
--- a/config/arm_clang.mk
+++ b/config/arm_clang.mk
@@ -26,9 +26,9 @@ endif
 
 LOCAL_COMPILER_CFLAGS := \
     --target=arm-none-eabi \
-    --sysroot=$(ARM_GCC_SYSROOT) \
     -I$(ARM_GCC_SYSROOT)/include/c++/$(ARM_GCC_VERSION) \
-    -I$(ARM_GCC_SYSROOT)/include/c++/$(ARM_GCC_VERSION)/arm-none-eabi/thumb/$(LOCAL_ARM_ARCHITECTURE)/$(LOCAL_ARM_FPU)/
+    -I$(ARM_GCC_SYSROOT)/include/c++/$(ARM_GCC_VERSION)/arm-none-eabi/thumb/$(LOCAL_ARM_ARCHITECTURE)/$(LOCAL_ARM_FPU)/ \
+    -I$(ARM_GCC_SYSROOT)/include
 
 LOCAL_COMPILER_CXXFLAGS := $(LOCAL_COMPILER_CFLAGS)
 


### PR DESCRIPTION
This issue is not reproducible with clang-10 or clang-11.

clang-12 invokes the linker with -L${SYSROOT}/lib which triggers an
issue because the arm-none-eabi-gcc sysroot has a multilib structure.

telling the linker to find libraries in that directory is
unfortunately wrong as it doesn't really take into account the
architecture of the platform.

This was causing the linker to link against an ARM library, inserting
blx instructions to transition to ARM from Thumb. Since the Cortex-M3
does not implement ARM, this triggers a fault.

Change-Id: Iadcea57727202858a00f8df5e8fbb038cfb25f2e